### PR TITLE
:memo: Fix syntax errors in readme

### DIFF
--- a/README.md
+++ b/README.md
@@ -35,11 +35,11 @@ Install svelte-command-palette with npm
 
     const actions = defineActions([
         {
-            id: 1,
+            actionId: 1,
             title: "Open Svelte Command Palette on github",
-            subTitle: 'This opens github in a new tab!",
+            subTitle: "This opens github in a new tab!",
             onRun: ({ action, storeProps, storeMethods }) => {
-                window.open("https://github.com/rohitpotato/svelte-command-palette"),
+                window.open("https://github.com/rohitpotato/svelte-command-palette")
             },
             shortcut: "Space k"
         }


### PR DESCRIPTION
Fixes minor readme syntax errors #4 