### PR TITLE
Change height to support single or double commands

### DIFF
--- a/src/lib/components/CommandPalette.svelte
+++ b/src/lib/components/CommandPalette.svelte
@@ -212,7 +212,7 @@
 		position: fixed;
 		top: 0;
 		left: 0;
-		height: 100vh;
+		max-height: 100vh;
 		width: 100vw;
 		background: transparent;
 		display: flex;


### PR DESCRIPTION
If the command palette has less than 3 options available, the list wrapper's box-shadow doesn't match. changing height to max-height solves this issue.