### PR TITLE
Fix native keyboard events not firing

### DIFF
--- a/src/lib/components/CommandPalette.svelte
+++ b/src/lib/components/CommandPalette.svelte
@@ -179,7 +179,7 @@
 	};
 
 	const handleSearch = (event: Event) => {
-		event.stopPropagation();
+		event.preventDefault();
 		let results = [...actions];
 		if ($paletteStore.textInput) {
 			const value = $paletteStore.textInput;

--- a/src/lib/components/CommandPalette.svelte
+++ b/src/lib/components/CommandPalette.svelte
@@ -92,8 +92,7 @@
 		lastActiveElement?.focus();
 	};
 
-	const closePalette = (event?: KeyboardEvent) => {
-		event?.preventDefault?.();
+	const closePalette = () => {
 		closeCommandPalette();
 		focusLastElement();
 	};
@@ -108,8 +107,7 @@
 		paletteStore.update((n: storeParams) => ({ ...n, activeCommandId: id }));
 	};
 
-	const handleArrowUp = (event: KeyboardEvent) => {
-		event.preventDefault();
+	const handleArrowUp = () => {
 		// get currently seleted item
 		let activeCommandIndex = searchResults.findIndex((a) => a.actionId === activeCommand) ?? 0;
 
@@ -120,8 +118,7 @@
 		setActiveCommand(searchResults[indexToSet].actionId || '');
 	};
 
-	const handleArrowDown = (event: KeyboardEvent) => {
-		event.preventDefault();
+	const handleArrowDown = () => {
 		if (searchResults.length) {
 			// get currently seleted item
 			let activeCommandIndex = searchResults.findIndex((a) => a.actionId === activeCommand) ?? 0;
@@ -133,8 +130,7 @@
 		}
 	};
 
-	const handleEnterKey = (event: KeyboardEvent) => {
-		event.preventDefault();
+	const handleEnterKey = () => {
 		// get active command and execute
 		const action = actionMap[activeCommand as string];
 		runAction({ action });
@@ -146,8 +142,7 @@
 		}
 	};
 
-	const toggleCommandPalette = (event: KeyboardEvent) => {
-		event.preventDefault();
+	const toggleCommandPalette = () => {
 		togglePalette();
 	};
 
@@ -178,8 +173,7 @@
 		}));
 	};
 
-	const handleSearch = (event: Event) => {
-		event.preventDefault();
+	const handleSearch = () => {
 		let results = [...actions];
 		if ($paletteStore.textInput) {
 			const value = $paletteStore.textInput;

--- a/src/lib/components/CommandPalette.svelte
+++ b/src/lib/components/CommandPalette.svelte
@@ -179,7 +179,6 @@
 	};
 
 	const handleSearch = (event: Event) => {
-		event.preventDefault();
 		let results = [...actions];
 		if ($paletteStore.textInput) {
 			const value = $paletteStore.textInput;

--- a/src/lib/components/CommandPalette.svelte
+++ b/src/lib/components/CommandPalette.svelte
@@ -179,6 +179,7 @@
 	};
 
 	const handleSearch = (event: Event) => {
+		event.preventDefault();
 		let results = [...actions];
 		if ($paletteStore.textInput) {
 			const value = $paletteStore.textInput;

--- a/src/lib/components/CommandPalette.svelte
+++ b/src/lib/components/CommandPalette.svelte
@@ -92,7 +92,8 @@
 		lastActiveElement?.focus();
 	};
 
-	const closePalette = () => {
+	const closePalette = (event?: KeyboardEvent) => {
+		event?.stopPropagation();
 		closeCommandPalette();
 		focusLastElement();
 	};
@@ -107,7 +108,8 @@
 		paletteStore.update((n: storeParams) => ({ ...n, activeCommandId: id }));
 	};
 
-	const handleArrowUp = () => {
+	const handleArrowUp = (event: KeyboardEvent) => {
+		event.stopPropagation();
 		// get currently seleted item
 		let activeCommandIndex = searchResults.findIndex((a) => a.actionId === activeCommand) ?? 0;
 
@@ -118,7 +120,8 @@
 		setActiveCommand(searchResults[indexToSet].actionId || '');
 	};
 
-	const handleArrowDown = () => {
+	const handleArrowDown = (event: KeyboardEvent) => {
+		event.stopPropagation();
 		if (searchResults.length) {
 			// get currently seleted item
 			let activeCommandIndex = searchResults.findIndex((a) => a.actionId === activeCommand) ?? 0;
@@ -130,7 +133,8 @@
 		}
 	};
 
-	const handleEnterKey = () => {
+	const handleEnterKey = (event: KeyboardEvent) => {
+		event.stopPropagation();
 		// get active command and execute
 		const action = actionMap[activeCommand as string];
 		runAction({ action });
@@ -142,7 +146,8 @@
 		}
 	};
 
-	const toggleCommandPalette = () => {
+	const toggleCommandPalette = (event: KeyboardEvent) => {
+		event.stopPropagation();
 		togglePalette();
 	};
 
@@ -173,7 +178,8 @@
 		}));
 	};
 
-	const handleSearch = () => {
+	const handleSearch = (event: Event) => {
+		event.stopPropagation();
 		let results = [...actions];
 		if ($paletteStore.textInput) {
 			const value = $paletteStore.textInput;

--- a/src/lib/components/CommandPalette.svelte
+++ b/src/lib/components/CommandPalette.svelte
@@ -147,7 +147,7 @@
 	};
 
 	const toggleCommandPalette = (event: KeyboardEvent) => {
-		event.stopPropagation();
+		event.preventDefault();
 		togglePalette();
 	};
 


### PR DESCRIPTION
This project seems somewhat inactive, but I was using it as a placeholder in a Svelte project. I came across a bug that was frustrating at first, but I fixed to keep it in place for some time. 
Also fixes some bugs mentioned in #16 
So I thought maybe you would appreciate it, I wonder what your opinion is.

Keyboard events like `keydown` on, i.e. `Enter`/`Return` have native implementations like navigating on anchor links.
When preventing this behaviour, the site becomes less accessible for keyboard users.
Instead of `e.preventDefault()`, using `e.stopPropagation()` prevents the event from propagating any further, but will not prevent other events.
As the command-palette should be placed on the root of your project, propagation probably won't go that much further, but it fixed it for now. When combined with a check whether the palette is open, the propagation is even safer.